### PR TITLE
feat: implement PriceLevel and OrderBook with full test coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ if(BUILD_TESTS)
 
     add_executable(orderbook_tests
         tests/unit/order_test.cpp
+        tests/unit/price_level_test.cpp
+        tests/unit/order_book_test.cpp
     )
 
     target_link_libraries(orderbook_tests

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.14"

--- a/include/orderbook/order_book.hpp
+++ b/include/orderbook/order_book.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "orderbook/types.hpp"
+#include "orderbook/price_level.hpp"
+
+#include <map>
+#include <unordered_map>
+#include <optional>
+#include <vector>
+
+namespace orderbook {
+
+/// Execution report generated when an order is added, cancelled, or modified.
+struct ExecutionReport {
+    enum class Type : uint8_t {
+        Accepted,
+        Cancelled,
+        Modified
+    };
+
+    Type    type;
+    OrderId order_id;
+};
+
+/// A complete order book for a single instrument (e.g., AAPL).
+///
+/// Contains two sides:
+///   - Bids: buy orders, sorted by price DESCENDING (best bid = highest price)
+///   - Asks: sell orders, sorted by price ASCENDING  (best ask = lowest price)
+///
+/// Design decisions (Phase 1):
+///   - std::map for price levels: O(log N) insert/lookup, ordered iteration.
+///     Good enough for correctness. We'll optimize in Phase 4.
+///   - std::unordered_map for order ID index: O(1) cancel/modify by ID.
+///   - Orders are owned externally (raw pointers). In Phase 4 we'll add
+///     an arena allocator. For now the caller manages Order lifetimes.
+class OrderBook {
+public:
+    OrderBook() = default;
+
+    // Non-copyable (contains PriceLevels which are non-copyable)
+    OrderBook(const OrderBook&) = delete;
+    OrderBook& operator=(const OrderBook&) = delete;
+
+    /// Add an order to the book. The order will be placed at the correct
+    /// side and price level. Returns Accepted report on success.
+    ///
+    /// Precondition: order->id must be unique (not already in the book).
+    /// The caller retains ownership of the Order memory.
+    ExecutionReport add_order(Order* order);
+
+    /// Cancel an order by its ID. Removes it from its price level.
+    /// Returns Cancelled report, or std::nullopt if the order wasn't found.
+    std::optional<ExecutionReport> cancel_order(OrderId order_id);
+
+    /// Modify an order's quantity. If the new quantity is less than the
+    /// filled quantity, the order is cancelled instead.
+    /// Reducing quantity preserves time priority.
+    /// Returns Modified or Cancelled report, or std::nullopt if not found.
+    std::optional<ExecutionReport> modify_order(OrderId order_id, Quantity new_quantity);
+
+    // ──────────────────────────────────────────
+    // Queries
+    // ──────────────────────────────────────────
+
+    /// Best bid price, or std::nullopt if no bids.
+    [[nodiscard]] std::optional<Price> best_bid() const;
+
+    /// Best ask price, or std::nullopt if no asks.
+    [[nodiscard]] std::optional<Price> best_ask() const;
+
+    /// Total resting quantity at a given price and side.
+    /// Returns 0 if no orders exist at that price.
+    [[nodiscard]] Quantity volume_at_price(Side side, Price price) const;
+
+    /// Number of distinct price levels on a given side.
+    [[nodiscard]] std::size_t level_count(Side side) const;
+
+    /// Total number of orders in the entire book (both sides).
+    [[nodiscard]] std::size_t order_count() const { return orders_.size(); }
+
+    /// Check if a specific order ID exists in the book.
+    [[nodiscard]] bool contains(OrderId order_id) const;
+
+    /// Get a pointer to an order by ID, or nullptr if not found.
+    [[nodiscard]] Order* find_order(OrderId order_id) const;
+
+private:
+    /// Bids: std::map with std::greater so begin() = highest price (best bid).
+    std::map<Price, PriceLevel, std::greater<Price>> bids_;
+
+    /// Asks: std::map with default std::less so begin() = lowest price (best ask).
+    std::map<Price, PriceLevel> asks_;
+
+    /// Order ID → Order pointer for O(1) lookups on cancel/modify.
+    std::unordered_map<OrderId, Order*> orders_;
+
+    /// Internal helpers
+    void remove_order_from_level(Order* order);
+};
+
+} // namespace orderbook

--- a/include/orderbook/price_level.hpp
+++ b/include/orderbook/price_level.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "orderbook/types.hpp"
+#include <cstddef>
+
+namespace orderbook {
+
+/// A FIFO queue of all resting orders at a single price.
+///
+/// Implemented as an intrusive doubly-linked list using the prev/next
+/// pointers embedded in each Order. This gives us:
+///   - O(1) append to tail  (new orders go to the back of the queue)
+///   - O(1) removal of any order (given a pointer to it)
+///   - O(1) total quantity lookup (cached, updated incrementally)
+///   - Zero heap allocations (no separate list nodes)
+///
+/// The FIFO ordering ensures price-time priority within a price level:
+/// the order that arrived first is at the head and gets filled first.
+class PriceLevel {
+public:
+    PriceLevel() = default;
+
+    // Non-copyable — orders hold raw pointers into this level's list
+    PriceLevel(const PriceLevel&) = delete;
+    PriceLevel& operator=(const PriceLevel&) = delete;
+
+    // Movable — needed for std::map emplacement
+    PriceLevel(PriceLevel&& other) noexcept;
+    PriceLevel& operator=(PriceLevel&& other) noexcept;
+
+    ~PriceLevel() = default;
+
+    /// Append an order to the back of the FIFO queue.
+    /// The order's prev/next pointers will be modified.
+    /// Precondition: order is not already in any list.
+    void add_order(Order* order);
+
+    /// Remove an order from the queue.
+    /// The order's prev/next pointers will be reset to nullptr.
+    /// Precondition: order is currently in THIS level's list.
+    void remove_order(Order* order);
+
+    /// The first order in the queue (earliest arrival). nullptr if empty.
+    [[nodiscard]] Order* front() const noexcept { return head_; }
+
+    /// The last order in the queue. nullptr if empty.
+    [[nodiscard]] Order* back() const noexcept { return tail_; }
+
+    /// Total remaining quantity across all orders at this price.
+    [[nodiscard]] Quantity total_quantity() const noexcept { return total_quantity_; }
+
+    /// Number of orders at this price level.
+    [[nodiscard]] std::size_t order_count() const noexcept { return order_count_; }
+
+    /// True if no orders are resting at this price.
+    [[nodiscard]] bool empty() const noexcept { return head_ == nullptr; }
+
+private:
+    Order*      head_{nullptr};
+    Order*      tail_{nullptr};
+    Quantity    total_quantity_{0};
+    std::size_t order_count_{0};
+};
+
+} // namespace orderbook

--- a/src/core/order_book.cpp
+++ b/src/core/order_book.cpp
@@ -1,13 +1,173 @@
 // src/core/order_book.cpp
-// OrderBook: bid/ask sides with price level management.
 //
-// Phase 1: Implement with std::map<Price, PriceLevel> for correctness.
-// Phase 4: Optimize to array-backed or custom container.
+// OrderBook: manages bid and ask sides for a single instrument.
+//
+// Phase 1 implementation uses std::map for price levels. This gives us
+// O(log N) insert/lookup with correct ordering out of the box.
+// Phase 4 will explore array-backed levels for O(1) access.
 
-#include "orderbook/types.hpp"
+#include "orderbook/order_book.hpp"
 
 namespace orderbook {
 
-// TODO (Phase 1): Implement OrderBook class
+// ──────────────────────────────────────────────
+// Order management
+// ──────────────────────────────────────────────
+
+ExecutionReport OrderBook::add_order(Order* order) {
+    // Index the order for O(1) cancel/modify lookups.
+    orders_[order->id] = order;
+
+    // Route to the correct side and emplace into the price level.
+    // std::map::operator[] default-constructs a PriceLevel if none exists
+    // at this price, which is exactly what we want.
+    if (order->side == Side::Buy) {
+        bids_[order->price].add_order(order);
+    } else {
+        asks_[order->price].add_order(order);
+    }
+
+    order->status = OrderStatus::Accepted;
+
+    return ExecutionReport{ExecutionReport::Type::Accepted, order->id};
+}
+
+std::optional<ExecutionReport> OrderBook::cancel_order(OrderId order_id) {
+    auto it = orders_.find(order_id);
+    if (it == orders_.end()) {
+        return std::nullopt;
+    }
+
+    Order* order = it->second;
+    remove_order_from_level(order);
+    orders_.erase(it);
+
+    order->status = OrderStatus::Cancelled;
+
+    return ExecutionReport{ExecutionReport::Type::Cancelled, order->id};
+}
+
+std::optional<ExecutionReport> OrderBook::modify_order(OrderId order_id, Quantity new_quantity) {
+    auto it = orders_.find(order_id);
+    if (it == orders_.end()) {
+        return std::nullopt;
+    }
+
+    Order* order = it->second;
+
+    // If new quantity is at or below what's already filled, cancel instead.
+    if (new_quantity <= order->filled_quantity) {
+        return cancel_order(order_id);
+    }
+
+    // Reducing quantity preserves time priority — we modify in place.
+    // Strategy: remove from level (with old quantity), update the order,
+    // then re-add (with new quantity). This keeps the level's cached
+    // total_quantity correct without needing to expose internals.
+    if (order->side == Side::Buy) {
+        auto level_it = bids_.find(order->price);
+        if (level_it != bids_.end()) {
+            level_it->second.remove_order(order);
+            order->quantity = new_quantity;
+            level_it->second.add_order(order);
+
+            if (level_it->second.empty()) {
+                bids_.erase(level_it);
+            }
+        }
+    } else {
+        auto level_it = asks_.find(order->price);
+        if (level_it != asks_.end()) {
+            level_it->second.remove_order(order);
+            order->quantity = new_quantity;
+            level_it->second.add_order(order);
+
+            if (level_it->second.empty()) {
+                asks_.erase(level_it);
+            }
+        }
+    }
+
+    return ExecutionReport{ExecutionReport::Type::Modified, order->id};
+}
+
+// ──────────────────────────────────────────────
+// Queries
+// ──────────────────────────────────────────────
+
+std::optional<Price> OrderBook::best_bid() const {
+    if (bids_.empty()) {
+        return std::nullopt;
+    }
+    // bids_ uses std::greater, so begin() is the highest price.
+    return bids_.begin()->first;
+}
+
+std::optional<Price> OrderBook::best_ask() const {
+    if (asks_.empty()) {
+        return std::nullopt;
+    }
+    // asks_ uses default std::less, so begin() is the lowest price.
+    return asks_.begin()->first;
+}
+
+Quantity OrderBook::volume_at_price(Side side, Price price) const {
+    if (side == Side::Buy) {
+        auto it = bids_.find(price);
+        if (it != bids_.end()) {
+            return it->second.total_quantity();
+        }
+    } else {
+        auto it = asks_.find(price);
+        if (it != asks_.end()) {
+            return it->second.total_quantity();
+        }
+    }
+    return 0;
+}
+
+std::size_t OrderBook::level_count(Side side) const {
+    if (side == Side::Buy) {
+        return bids_.size();
+    }
+    return asks_.size();
+}
+
+bool OrderBook::contains(OrderId order_id) const {
+    return orders_.find(order_id) != orders_.end();
+}
+
+Order* OrderBook::find_order(OrderId order_id) const {
+    auto it = orders_.find(order_id);
+    if (it != orders_.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+// ──────────────────────────────────────────────
+// Internal helpers
+// ──────────────────────────────────────────────
+
+void OrderBook::remove_order_from_level(Order* order) {
+    if (order->side == Side::Buy) {
+        auto it = bids_.find(order->price);
+        if (it != bids_.end()) {
+            it->second.remove_order(order);
+            // Remove empty price levels to keep the map clean.
+            if (it->second.empty()) {
+                bids_.erase(it);
+            }
+        }
+    } else {
+        auto it = asks_.find(order->price);
+        if (it != asks_.end()) {
+            it->second.remove_order(order);
+            if (it->second.empty()) {
+                asks_.erase(it);
+            }
+        }
+    }
+}
 
 } // namespace orderbook

--- a/src/core/price_level.cpp
+++ b/src/core/price_level.cpp
@@ -1,12 +1,93 @@
 // src/core/price_level.cpp
+//
 // PriceLevel: FIFO queue of orders at a single price.
 //
-// Phase 1: Implement intrusive doubly-linked list with cached total quantity.
+// This is the most performance-critical data structure in the order book.
+// Every add, cancel, and match operation touches a PriceLevel.
+// The intrusive list avoids heap allocations and keeps operations O(1).
 
-#include "orderbook/types.hpp"
+#include "orderbook/price_level.hpp"
 
 namespace orderbook {
 
-// TODO (Phase 1): Implement PriceLevel class
+// ──────────────────────────────────────────────
+// Move operations
+// ──────────────────────────────────────────────
+
+PriceLevel::PriceLevel(PriceLevel&& other) noexcept
+    : head_{other.head_}
+    , tail_{other.tail_}
+    , total_quantity_{other.total_quantity_}
+    , order_count_{other.order_count_}
+{
+    other.head_ = nullptr;
+    other.tail_ = nullptr;
+    other.total_quantity_ = 0;
+    other.order_count_ = 0;
+}
+
+PriceLevel& PriceLevel::operator=(PriceLevel&& other) noexcept {
+    if (this != &other) {
+        head_           = other.head_;
+        tail_           = other.tail_;
+        total_quantity_ = other.total_quantity_;
+        order_count_    = other.order_count_;
+
+        other.head_ = nullptr;
+        other.tail_ = nullptr;
+        other.total_quantity_ = 0;
+        other.order_count_ = 0;
+    }
+    return *this;
+}
+
+// ──────────────────────────────────────────────
+// Core operations
+// ──────────────────────────────────────────────
+
+void PriceLevel::add_order(Order* order) {
+    // Wire the new order to the end of the list.
+    order->prev = tail_;
+    order->next = nullptr;
+
+    if (tail_ != nullptr) {
+        // List is non-empty: link current tail to the new order.
+        tail_->next = order;
+    } else {
+        // List was empty: new order is also the head.
+        head_ = order;
+    }
+
+    tail_ = order;
+
+    // Update cached aggregates.
+    total_quantity_ += order->remaining_quantity();
+    ++order_count_;
+}
+
+void PriceLevel::remove_order(Order* order) {
+    // Unlink from the doubly-linked list.
+    if (order->prev != nullptr) {
+        order->prev->next = order->next;
+    } else {
+        // Removing the head — advance head to the next order.
+        head_ = order->next;
+    }
+
+    if (order->next != nullptr) {
+        order->next->prev = order->prev;
+    } else {
+        // Removing the tail — retreat tail to the previous order.
+        tail_ = order->prev;
+    }
+
+    // Clean up the order's list pointers.
+    order->prev = nullptr;
+    order->next = nullptr;
+
+    // Update cached aggregates.
+    total_quantity_ -= order->remaining_quantity();
+    --order_count_;
+}
 
 } // namespace orderbook

--- a/tests/unit/order_book_test.cpp
+++ b/tests/unit/order_book_test.cpp
@@ -1,0 +1,283 @@
+#include <gtest/gtest.h>
+#include "orderbook/order_book.hpp"
+#include <vector>
+
+using namespace orderbook;
+
+// ──────────────────────────────────────────────
+// Helper: create orders conveniently
+// ──────────────────────────────────────────────
+static Order make_buy(OrderId id, Price price, Quantity qty) {
+    Order o{};
+    o.id = id;
+    o.price = price;
+    o.quantity = qty;
+    o.side = Side::Buy;
+    return o;
+}
+
+static Order make_sell(OrderId id, Price price, Quantity qty) {
+    Order o{};
+    o.id = id;
+    o.price = price;
+    o.quantity = qty;
+    o.side = Side::Sell;
+    return o;
+}
+
+// ──────────────────────────────────────────────
+// Empty book
+// ──────────────────────────────────────────────
+
+TEST(OrderBookTest, EmptyBook) {
+    OrderBook book;
+    EXPECT_EQ(book.order_count(), 0);
+    EXPECT_EQ(book.best_bid(), std::nullopt);
+    EXPECT_EQ(book.best_ask(), std::nullopt);
+    EXPECT_EQ(book.level_count(Side::Buy), 0);
+    EXPECT_EQ(book.level_count(Side::Sell), 0);
+}
+
+// ──────────────────────────────────────────────
+// Adding orders
+// ──────────────────────────────────────────────
+
+TEST(OrderBookTest, AddSingleBid) {
+    OrderBook book;
+    Order bid = make_buy(1, 10000, 100);
+
+    auto report = book.add_order(&bid);
+
+    EXPECT_EQ(report.type, ExecutionReport::Type::Accepted);
+    EXPECT_EQ(report.order_id, 1);
+    EXPECT_EQ(book.order_count(), 1);
+    EXPECT_EQ(book.best_bid(), 10000);
+    EXPECT_EQ(book.best_ask(), std::nullopt);
+    EXPECT_EQ(book.volume_at_price(Side::Buy, 10000), 100);
+}
+
+TEST(OrderBookTest, AddSingleAsk) {
+    OrderBook book;
+    Order ask = make_sell(1, 10050, 200);
+
+    book.add_order(&ask);
+
+    EXPECT_EQ(book.best_ask(), 10050);
+    EXPECT_EQ(book.best_bid(), std::nullopt);
+    EXPECT_EQ(book.volume_at_price(Side::Sell, 10050), 200);
+}
+
+TEST(OrderBookTest, BestBidIsHighestPrice) {
+    OrderBook book;
+    Order b1 = make_buy(1, 10000, 100);
+    Order b2 = make_buy(2, 10050, 100);
+    Order b3 = make_buy(3, 9950, 100);
+
+    book.add_order(&b1);
+    book.add_order(&b2);
+    book.add_order(&b3);
+
+    EXPECT_EQ(book.best_bid(), 10050); // Highest bid wins
+    EXPECT_EQ(book.level_count(Side::Buy), 3);
+}
+
+TEST(OrderBookTest, BestAskIsLowestPrice) {
+    OrderBook book;
+    Order a1 = make_sell(1, 10100, 100);
+    Order a2 = make_sell(2, 10050, 100);
+    Order a3 = make_sell(3, 10200, 100);
+
+    book.add_order(&a1);
+    book.add_order(&a2);
+    book.add_order(&a3);
+
+    EXPECT_EQ(book.best_ask(), 10050); // Lowest ask wins
+    EXPECT_EQ(book.level_count(Side::Sell), 3);
+}
+
+TEST(OrderBookTest, MultipleOrdersSamePrice) {
+    OrderBook book;
+    Order b1 = make_buy(1, 10000, 100);
+    Order b2 = make_buy(2, 10000, 200);
+    Order b3 = make_buy(3, 10000, 50);
+
+    book.add_order(&b1);
+    book.add_order(&b2);
+    book.add_order(&b3);
+
+    EXPECT_EQ(book.level_count(Side::Buy), 1); // All at same price level
+    EXPECT_EQ(book.volume_at_price(Side::Buy, 10000), 350);
+    EXPECT_EQ(book.order_count(), 3);
+}
+
+// ──────────────────────────────────────────────
+// Cancelling orders
+// ──────────────────────────────────────────────
+
+TEST(OrderBookTest, CancelOrder) {
+    OrderBook book;
+    Order bid = make_buy(1, 10000, 100);
+    book.add_order(&bid);
+
+    auto report = book.cancel_order(1);
+
+    ASSERT_TRUE(report.has_value());
+    EXPECT_EQ(report->type, ExecutionReport::Type::Cancelled);
+    EXPECT_EQ(book.order_count(), 0);
+    EXPECT_EQ(book.best_bid(), std::nullopt);
+    EXPECT_EQ(bid.status, OrderStatus::Cancelled);
+}
+
+TEST(OrderBookTest, CancelNonexistentOrder) {
+    OrderBook book;
+    auto report = book.cancel_order(999);
+    EXPECT_FALSE(report.has_value());
+}
+
+TEST(OrderBookTest, CancelRemovesEmptyPriceLevel) {
+    OrderBook book;
+    Order bid = make_buy(1, 10000, 100);
+    book.add_order(&bid);
+
+    book.cancel_order(1);
+
+    EXPECT_EQ(book.level_count(Side::Buy), 0);
+    EXPECT_EQ(book.volume_at_price(Side::Buy, 10000), 0);
+}
+
+TEST(OrderBookTest, CancelOneOfMultipleAtSamePrice) {
+    OrderBook book;
+    Order b1 = make_buy(1, 10000, 100);
+    Order b2 = make_buy(2, 10000, 200);
+
+    book.add_order(&b1);
+    book.add_order(&b2);
+
+    book.cancel_order(1);
+
+    EXPECT_EQ(book.level_count(Side::Buy), 1);  // Level still exists
+    EXPECT_EQ(book.volume_at_price(Side::Buy, 10000), 200);
+    EXPECT_EQ(book.order_count(), 1);
+    EXPECT_FALSE(book.contains(1));
+    EXPECT_TRUE(book.contains(2));
+}
+
+TEST(OrderBookTest, CancelBestBidRevealNextBest) {
+    OrderBook book;
+    Order b1 = make_buy(1, 10050, 100); // Best bid
+    Order b2 = make_buy(2, 10000, 100); // Second best
+
+    book.add_order(&b1);
+    book.add_order(&b2);
+
+    EXPECT_EQ(book.best_bid(), 10050);
+
+    book.cancel_order(1);
+
+    EXPECT_EQ(book.best_bid(), 10000); // Second best is now the best
+}
+
+// ──────────────────────────────────────────────
+// Modifying orders
+// ──────────────────────────────────────────────
+
+TEST(OrderBookTest, ModifyReduceQuantity) {
+    OrderBook book;
+    Order bid = make_buy(1, 10000, 100);
+    book.add_order(&bid);
+
+    auto report = book.modify_order(1, 60);
+
+    ASSERT_TRUE(report.has_value());
+    EXPECT_EQ(report->type, ExecutionReport::Type::Modified);
+    EXPECT_EQ(book.volume_at_price(Side::Buy, 10000), 60);
+    EXPECT_EQ(bid.quantity, 60);
+}
+
+TEST(OrderBookTest, ModifyToZeroCancels) {
+    OrderBook book;
+    Order bid = make_buy(1, 10000, 100);
+    book.add_order(&bid);
+
+    auto report = book.modify_order(1, 0);
+
+    ASSERT_TRUE(report.has_value());
+    EXPECT_EQ(report->type, ExecutionReport::Type::Cancelled);
+    EXPECT_EQ(book.order_count(), 0);
+}
+
+TEST(OrderBookTest, ModifyNonexistentOrder) {
+    OrderBook book;
+    auto report = book.modify_order(999, 50);
+    EXPECT_FALSE(report.has_value());
+}
+
+// ──────────────────────────────────────────────
+// Queries
+// ──────────────────────────────────────────────
+
+TEST(OrderBookTest, VolumeAtPriceNoOrders) {
+    OrderBook book;
+    EXPECT_EQ(book.volume_at_price(Side::Buy, 10000), 0);
+    EXPECT_EQ(book.volume_at_price(Side::Sell, 10000), 0);
+}
+
+TEST(OrderBookTest, ContainsAndFindOrder) {
+    OrderBook book;
+    Order bid = make_buy(1, 10000, 100);
+    book.add_order(&bid);
+
+    EXPECT_TRUE(book.contains(1));
+    EXPECT_FALSE(book.contains(2));
+    EXPECT_EQ(book.find_order(1), &bid);
+    EXPECT_EQ(book.find_order(2), nullptr);
+}
+
+// ──────────────────────────────────────────────
+// Full book scenario
+// ──────────────────────────────────────────────
+
+TEST(OrderBookTest, RealisticBookBuildup) {
+    OrderBook book;
+
+    // Build a realistic book:
+    // Bids: 100.00, 99.95, 99.90
+    // Asks: 100.05, 100.10, 100.15
+    Order b1 = make_buy(1, 10000, 500);
+    Order b2 = make_buy(2, 9995,  300);
+    Order b3 = make_buy(3, 9990,  200);
+    Order b4 = make_buy(4, 10000, 100); // Second order at best bid
+
+    Order a1 = make_sell(5, 10005, 400);
+    Order a2 = make_sell(6, 10010, 250);
+    Order a3 = make_sell(7, 10015, 150);
+    Order a4 = make_sell(8, 10005, 200); // Second order at best ask
+
+    book.add_order(&b1);
+    book.add_order(&b2);
+    book.add_order(&b3);
+    book.add_order(&b4);
+    book.add_order(&a1);
+    book.add_order(&a2);
+    book.add_order(&a3);
+    book.add_order(&a4);
+
+    // Verify the book state.
+    EXPECT_EQ(book.order_count(), 8);
+    EXPECT_EQ(book.best_bid(), 10000);
+    EXPECT_EQ(book.best_ask(), 10005);
+    EXPECT_EQ(book.level_count(Side::Buy), 3);
+    EXPECT_EQ(book.level_count(Side::Sell), 3);
+    EXPECT_EQ(book.volume_at_price(Side::Buy, 10000), 600);  // 500 + 100
+    EXPECT_EQ(book.volume_at_price(Side::Sell, 10005), 600);  // 400 + 200
+
+    // Spread = best ask - best bid = 100.05 - 100.00 = 0.05 = 5 ticks
+    EXPECT_EQ(*book.best_ask() - *book.best_bid(), 5);
+
+    // Cancel the best bid entirely.
+    book.cancel_order(1); // Remove 500 from 100.00
+    book.cancel_order(4); // Remove 100 from 100.00
+
+    EXPECT_EQ(book.best_bid(), 9995); // Next best bid
+    EXPECT_EQ(book.level_count(Side::Buy), 2); // 100.00 level gone
+}

--- a/tests/unit/order_test.cpp
+++ b/tests/unit/order_test.cpp
@@ -27,15 +27,25 @@ TEST(OrderTest, RemainingQuantity) {
     EXPECT_EQ(order.remaining_quantity(), 65);
 }
 
-TEST(OrderTest, IsFilled) {
+TEST(OrderTest, RemainingQuantityWhenUnfilled) {
+    Order order{};
+    order.quantity = 500;
+    order.filled_quantity = 0;
+    EXPECT_EQ(order.remaining_quantity(), 500);
+}
+
+TEST(OrderTest, IsFilledExact) {
     Order order{};
     order.quantity = 100;
-
-    order.filled_quantity = 50;
-    EXPECT_FALSE(order.is_filled());
-
     order.filled_quantity = 100;
     EXPECT_TRUE(order.is_filled());
+}
+
+TEST(OrderTest, IsFilledPartial) {
+    Order order{};
+    order.quantity = 100;
+    order.filled_quantity = 50;
+    EXPECT_FALSE(order.is_filled());
 }
 
 TEST(OrderTest, FixedPointPricing) {

--- a/tests/unit/price_level_test.cpp
+++ b/tests/unit/price_level_test.cpp
@@ -1,0 +1,211 @@
+#include <gtest/gtest.h>
+#include "orderbook/price_level.hpp"
+#include <vector>
+
+using namespace orderbook;
+
+// ──────────────────────────────────────────────
+// Helper: create an order with given id and quantity
+// ──────────────────────────────────────────────
+static Order make_order(OrderId id, Quantity qty, Price price = 10000) {
+    Order o{};
+    o.id = id;
+    o.price = price;
+    o.quantity = qty;
+    o.side = Side::Buy;
+    return o;
+}
+
+// ──────────────────────────────────────────────
+// Basic operations
+// ──────────────────────────────────────────────
+
+TEST(PriceLevelTest, EmptyByDefault) {
+    PriceLevel level;
+    EXPECT_TRUE(level.empty());
+    EXPECT_EQ(level.order_count(), 0);
+    EXPECT_EQ(level.total_quantity(), 0);
+    EXPECT_EQ(level.front(), nullptr);
+    EXPECT_EQ(level.back(), nullptr);
+}
+
+TEST(PriceLevelTest, AddSingleOrder) {
+    PriceLevel level;
+    Order order = make_order(1, 100);
+
+    level.add_order(&order);
+
+    EXPECT_FALSE(level.empty());
+    EXPECT_EQ(level.order_count(), 1);
+    EXPECT_EQ(level.total_quantity(), 100);
+    EXPECT_EQ(level.front(), &order);
+    EXPECT_EQ(level.back(), &order);
+}
+
+TEST(PriceLevelTest, AddMultipleOrdersFIFO) {
+    PriceLevel level;
+    Order o1 = make_order(1, 100);
+    Order o2 = make_order(2, 200);
+    Order o3 = make_order(3, 50);
+
+    level.add_order(&o1);
+    level.add_order(&o2);
+    level.add_order(&o3);
+
+    // Head should be the first order added (FIFO).
+    EXPECT_EQ(level.front(), &o1);
+    EXPECT_EQ(level.back(), &o3);
+    EXPECT_EQ(level.order_count(), 3);
+    EXPECT_EQ(level.total_quantity(), 350);
+
+    // Walk the list and verify FIFO ordering.
+    EXPECT_EQ(o1.next, &o2);
+    EXPECT_EQ(o2.next, &o3);
+    EXPECT_EQ(o3.next, nullptr);
+    EXPECT_EQ(o3.prev, &o2);
+    EXPECT_EQ(o2.prev, &o1);
+    EXPECT_EQ(o1.prev, nullptr);
+}
+
+// ──────────────────────────────────────────────
+// Removal
+// ──────────────────────────────────────────────
+
+TEST(PriceLevelTest, RemoveOnlyOrder) {
+    PriceLevel level;
+    Order order = make_order(1, 100);
+
+    level.add_order(&order);
+    level.remove_order(&order);
+
+    EXPECT_TRUE(level.empty());
+    EXPECT_EQ(level.order_count(), 0);
+    EXPECT_EQ(level.total_quantity(), 0);
+    EXPECT_EQ(level.front(), nullptr);
+    EXPECT_EQ(level.back(), nullptr);
+    EXPECT_EQ(order.prev, nullptr);
+    EXPECT_EQ(order.next, nullptr);
+}
+
+TEST(PriceLevelTest, RemoveHead) {
+    PriceLevel level;
+    Order o1 = make_order(1, 100);
+    Order o2 = make_order(2, 200);
+    Order o3 = make_order(3, 50);
+
+    level.add_order(&o1);
+    level.add_order(&o2);
+    level.add_order(&o3);
+
+    level.remove_order(&o1);
+
+    EXPECT_EQ(level.front(), &o2);
+    EXPECT_EQ(level.back(), &o3);
+    EXPECT_EQ(level.order_count(), 2);
+    EXPECT_EQ(level.total_quantity(), 250);
+    EXPECT_EQ(o2.prev, nullptr); // o2 is now the head
+}
+
+TEST(PriceLevelTest, RemoveTail) {
+    PriceLevel level;
+    Order o1 = make_order(1, 100);
+    Order o2 = make_order(2, 200);
+    Order o3 = make_order(3, 50);
+
+    level.add_order(&o1);
+    level.add_order(&o2);
+    level.add_order(&o3);
+
+    level.remove_order(&o3);
+
+    EXPECT_EQ(level.front(), &o1);
+    EXPECT_EQ(level.back(), &o2);
+    EXPECT_EQ(level.order_count(), 2);
+    EXPECT_EQ(level.total_quantity(), 300);
+    EXPECT_EQ(o2.next, nullptr); // o2 is now the tail
+}
+
+TEST(PriceLevelTest, RemoveMiddle) {
+    PriceLevel level;
+    Order o1 = make_order(1, 100);
+    Order o2 = make_order(2, 200);
+    Order o3 = make_order(3, 50);
+
+    level.add_order(&o1);
+    level.add_order(&o2);
+    level.add_order(&o3);
+
+    level.remove_order(&o2);
+
+    // o1 and o3 should now be directly linked.
+    EXPECT_EQ(level.front(), &o1);
+    EXPECT_EQ(level.back(), &o3);
+    EXPECT_EQ(o1.next, &o3);
+    EXPECT_EQ(o3.prev, &o1);
+    EXPECT_EQ(level.order_count(), 2);
+    EXPECT_EQ(level.total_quantity(), 150);
+}
+
+// ──────────────────────────────────────────────
+// Quantity tracking with partial fills
+// ──────────────────────────────────────────────
+
+TEST(PriceLevelTest, QuantityReflectsRemainingNotTotal) {
+    PriceLevel level;
+    Order order = make_order(1, 100);
+    order.filled_quantity = 30; // Only 70 remaining
+
+    level.add_order(&order);
+
+    EXPECT_EQ(level.total_quantity(), 70);
+}
+
+// ──────────────────────────────────────────────
+// Stress: add and remove many orders
+// ──────────────────────────────────────────────
+
+TEST(PriceLevelTest, AddAndRemoveMany) {
+    PriceLevel level;
+    constexpr int N = 1000;
+    std::vector<Order> orders(N);
+
+    for (int i = 0; i < N; ++i) {
+        orders[static_cast<std::size_t>(i)] = make_order(
+            static_cast<OrderId>(i + 1), 10
+        );
+        level.add_order(&orders[static_cast<std::size_t>(i)]);
+    }
+
+    EXPECT_EQ(level.order_count(), N);
+    EXPECT_EQ(level.total_quantity(), static_cast<Quantity>(N * 10));
+
+    // Remove all orders from the front (simulating fills in FIFO order).
+    for (int i = 0; i < N; ++i) {
+        EXPECT_EQ(level.front()->id, static_cast<OrderId>(i + 1));
+        level.remove_order(level.front());
+    }
+
+    EXPECT_TRUE(level.empty());
+    EXPECT_EQ(level.total_quantity(), 0);
+}
+
+// ──────────────────────────────────────────────
+// Move semantics
+// ──────────────────────────────────────────────
+
+TEST(PriceLevelTest, MoveConstruction) {
+    PriceLevel level;
+    Order o1 = make_order(1, 100);
+    Order o2 = make_order(2, 200);
+    level.add_order(&o1);
+    level.add_order(&o2);
+
+    PriceLevel moved(std::move(level));
+
+    EXPECT_EQ(moved.order_count(), 2);
+    EXPECT_EQ(moved.total_quantity(), 300);
+    EXPECT_EQ(moved.front(), &o1);
+
+    // Source should be empty after move.
+    EXPECT_TRUE(level.empty()); // NOLINT(bugprone-use-after-move)
+}


### PR DESCRIPTION
- PriceLevel: intrusive doubly-linked FIFO queue with O(1) add/remove and cached total quantity
- OrderBook: bid/ask sides using std::map with O(1) best bid/ask, O(1) cancel via order ID index
- 25 unit tests covering FIFO ordering, removal edge cases, quantity tracking, modify, and realistic book scenarios