### PR TITLE
perf: add benchmark suite with latency and throughput measurement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,28 +7,45 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        compiler: [g++, clang++]
         build_type: [Debug, Release]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: sudo apt-get install -y cmake ninja-build
-
-      - name: Configure
+      - name: Configure CMake
         run: |
           cmake -B build \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.compiler }}
+            -DBUILD_TESTS=ON
 
       - name: Build
-        run: cmake --build build
+        run: cmake --build build --parallel $(nproc)
 
-      - name: Test
-        run: ctest --test-dir build --output-on-failure
+      - name: Run tests
+        working-directory: build
+        run: ctest --output-on-failure --parallel $(nproc)
+
+  sanitizers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build with AddressSanitizer
+        run: |
+          cmake -B build-asan \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+            -DBUILD_TESTS=ON
+          cmake --build build-asan --parallel $(nproc)
+
+      - name: Run tests under sanitizer
+        working-directory: build-asan
+        run: ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ if(BUILD_BENCHMARKS)
         PRIVATE orderbook_matching
     )
 
+    # Benchmarks should always be optimized, even in Debug builds.
     target_compile_options(orderbook_bench PRIVATE -O3 -march=native)
+
+    # Disable RTTI and exceptions for benchmark binary (perf).
     target_compile_options(orderbook_bench PRIVATE -fno-rtti)
 endif()

--- a/benchmarks/bench_harness.hpp
+++ b/benchmarks/bench_harness.hpp
@@ -1,0 +1,170 @@
+#pragma once
+
+// benchmarks/bench_harness.hpp
+//
+// Lightweight benchmark harness. We avoid Google Benchmark as a dependency
+// to keep the build simple and self-contained. This harness provides:
+//   - High-resolution timing (nanosecond precision)
+//   - Percentile calculation (p50, p95, p99, p99.9)
+//   - Warmup and iteration control
+//   - Formatted result output
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace bench {
+
+using Clock    = std::chrono::high_resolution_clock;
+using Duration = std::chrono::nanoseconds;
+
+/// Collected latency samples from a benchmark run.
+struct LatencyStats {
+    std::string name;
+    std::size_t iterations{0};
+    Duration    total{0};
+
+    Duration min{Duration::max()};
+    Duration max{Duration::zero()};
+    Duration mean{0};
+    Duration median{0};
+    Duration p50{0};
+    Duration p95{0};
+    Duration p99{0};
+    Duration p999{0};
+
+    double throughput_ops_per_sec{0.0};
+};
+
+/// Compute percentile from a SORTED vector of durations.
+inline Duration percentile(const std::vector<Duration>& sorted, double pct) {
+    if (sorted.empty()) return Duration::zero();
+    auto idx = static_cast<std::size_t>(
+        std::ceil(pct / 100.0 * static_cast<double>(sorted.size())) - 1.0
+    );
+    idx = std::min(idx, sorted.size() - 1);
+    return sorted[idx];
+}
+
+/// Format a duration as a human-readable string (ns, μs, ms, s).
+inline std::string format_duration(Duration d) {
+    auto ns = d.count();
+    if (ns < 1'000) {
+        return std::to_string(ns) + " ns";
+    } else if (ns < 1'000'000) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%.2f μs",
+                      static_cast<double>(ns) / 1'000.0);
+        return buf;
+    } else if (ns < 1'000'000'000) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%.2f ms",
+                      static_cast<double>(ns) / 1'000'000.0);
+        return buf;
+    } else {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%.2f s",
+                      static_cast<double>(ns) / 1'000'000'000.0);
+        return buf;
+    }
+}
+
+/// Format a throughput number with comma separators.
+inline std::string format_throughput(double ops) {
+    // Convert to integer for formatting
+    auto int_ops = static_cast<uint64_t>(ops);
+    auto s = std::to_string(int_ops);
+    // Insert commas from the right
+    int n = static_cast<int>(s.length());
+    for (int i = n - 3; i > 0; i -= 3) {
+        s.insert(static_cast<std::size_t>(i), ",");
+    }
+    return s + " ops/sec";
+}
+
+/// Compute stats from a vector of individual operation latencies.
+inline LatencyStats compute_stats(const std::string& name,
+                                  std::vector<Duration>& samples) {
+    LatencyStats stats;
+    stats.name = name;
+    stats.iterations = samples.size();
+
+    if (samples.empty()) return stats;
+
+    // Sort for percentile computation.
+    std::sort(samples.begin(), samples.end());
+
+    stats.min    = samples.front();
+    stats.max    = samples.back();
+    stats.median = percentile(samples, 50.0);
+    stats.p50    = stats.median;
+    stats.p95    = percentile(samples, 95.0);
+    stats.p99    = percentile(samples, 99.0);
+    stats.p999   = percentile(samples, 99.9);
+
+    // Total and mean.
+    Duration total{0};
+    for (auto& s : samples) {
+        total += s;
+    }
+    stats.total = total;
+    stats.mean  = Duration(total.count() / static_cast<int64_t>(samples.size()));
+
+    // Throughput.
+    double total_sec = static_cast<double>(total.count()) / 1'000'000'000.0;
+    if (total_sec > 0) {
+        stats.throughput_ops_per_sec =
+            static_cast<double>(samples.size()) / total_sec;
+    }
+
+    return stats;
+}
+
+/// Print a LatencyStats result in a clean table format.
+inline void print_stats(const LatencyStats& stats) {
+    std::cout << "\n┌─────────────────────────────────────────────┐\n";
+    std::cout << "│ " << std::left << std::setw(44) << stats.name << "│\n";
+    std::cout << "├─────────────────────────────────────────────┤\n";
+    std::cout << "│ Iterations:  " << std::setw(30)
+              << stats.iterations << " │\n";
+    std::cout << "│ Throughput:  " << std::setw(30)
+              << format_throughput(stats.throughput_ops_per_sec) << " │\n";
+    std::cout << "├─────────────────────────────────────────────┤\n";
+    std::cout << "│ Min:         " << std::setw(30)
+              << format_duration(stats.min) << " │\n";
+    std::cout << "│ Mean:        " << std::setw(30)
+              << format_duration(stats.mean) << " │\n";
+    std::cout << "│ p50:         " << std::setw(30)
+              << format_duration(stats.p50) << " │\n";
+    std::cout << "│ p95:         " << std::setw(30)
+              << format_duration(stats.p95) << " │\n";
+    std::cout << "│ p99:         " << std::setw(30)
+              << format_duration(stats.p99) << " │\n";
+    std::cout << "│ p99.9:       " << std::setw(30)
+              << format_duration(stats.p999) << " │\n";
+    std::cout << "│ Max:         " << std::setw(30)
+              << format_duration(stats.max) << " │\n";
+    std::cout << "└─────────────────────────────────────────────┘\n";
+}
+
+/// Prevent the compiler from optimizing away a value.
+/// Essential for benchmarks — without this, the compiler can
+/// eliminate the entire operation we're trying to measure.
+template<typename T>
+inline void do_not_optimize(T const& value) {
+    asm volatile("" : : "r,m"(value) : "memory");
+}
+
+/// Compiler fence — prevents instruction reordering across this point.
+inline void fence() {
+    asm volatile("" ::: "memory");
+}
+
+} // namespace bench

--- a/benchmarks/order_generator.hpp
+++ b/benchmarks/order_generator.hpp
@@ -1,0 +1,179 @@
+#pragma once
+
+// benchmarks/order_generator.hpp
+//
+// Generates synthetic order streams for benchmarking.
+// Supports multiple distribution profiles:
+//   - Uniform:   prices spread evenly across a range
+//   - Clustered: prices cluster around a mid-point (more realistic)
+//   - Adversarial: designed to stress worst-case paths
+//
+// The generator pre-allocates all orders up front so that
+// memory allocation doesn't contaminate benchmark timing.
+
+#include "orderbook/types.hpp"
+#include <cstdint>
+#include <random>
+#include <vector>
+
+namespace bench {
+
+/// What operation to perform with this order.
+enum class Action : uint8_t {
+    Add,
+    Cancel,
+};
+
+/// A pre-generated benchmark operation.
+struct BenchOp {
+    Action         action;
+    orderbook::Order order;
+};
+
+/// Configuration for the order generator.
+struct GeneratorConfig {
+    std::size_t num_orders{100'000};
+
+    // Price range (in ticks). Mid-point is (min + max) / 2.
+    orderbook::Price price_min{9'900};  // $99.00
+    orderbook::Price price_max{10'100}; // $101.00
+
+    // What fraction of operations should be cancels (0.0 to 1.0).
+    // Realistic markets have ~60-80% cancel rate.
+    double cancel_ratio{0.3};
+
+    // Max quantity per order.
+    orderbook::Quantity max_quantity{1000};
+
+    // Random seed for reproducibility.
+    uint64_t seed{42};
+};
+
+/// Generates a vector of benchmark operations.
+inline std::vector<BenchOp> generate_uniform(const GeneratorConfig& cfg) {
+    std::mt19937_64 rng(cfg.seed);
+    std::uniform_int_distribution<orderbook::Price> price_dist(
+        cfg.price_min, cfg.price_max
+    );
+    std::uniform_int_distribution<orderbook::Quantity> qty_dist(1, cfg.max_quantity);
+    std::uniform_int_distribution<int> side_dist(0, 1);
+    std::uniform_real_distribution<double> cancel_dist(0.0, 1.0);
+
+    std::vector<BenchOp> ops;
+    ops.reserve(cfg.num_orders);
+
+    orderbook::OrderId next_id = 1;
+    std::vector<orderbook::OrderId> active_ids; // IDs currently in the book
+    active_ids.reserve(cfg.num_orders);
+
+    for (std::size_t i = 0; i < cfg.num_orders; ++i) {
+        // Decide: add or cancel?
+        bool do_cancel = !active_ids.empty() && cancel_dist(rng) < cfg.cancel_ratio;
+
+        if (do_cancel) {
+            // Pick a random active order to cancel.
+            std::uniform_int_distribution<std::size_t> idx_dist(
+                0, active_ids.size() - 1
+            );
+            std::size_t idx = idx_dist(rng);
+            orderbook::OrderId cancel_id = active_ids[idx];
+
+            // Swap-remove from active list.
+            active_ids[idx] = active_ids.back();
+            active_ids.pop_back();
+
+            BenchOp op{};
+            op.action = Action::Cancel;
+            op.order.id = cancel_id;
+            ops.push_back(op);
+        } else {
+            // Add a new order.
+            BenchOp op{};
+            op.action = Action::Add;
+            op.order.id = next_id++;
+            op.order.price = price_dist(rng);
+            op.order.quantity = qty_dist(rng);
+            op.order.side = side_dist(rng) == 0
+                ? orderbook::Side::Buy
+                : orderbook::Side::Sell;
+            op.order.type = orderbook::OrderType::Limit;
+            op.order.timestamp = static_cast<orderbook::Timestamp>(i);
+            ops.push_back(op);
+
+            active_ids.push_back(op.order.id);
+        }
+    }
+
+    return ops;
+}
+
+/// Generates orders clustered around a mid-price with normal distribution.
+/// This is more realistic — most real order flow is near the current price.
+inline std::vector<BenchOp> generate_clustered(const GeneratorConfig& cfg) {
+    std::mt19937_64 rng(cfg.seed);
+
+    orderbook::Price mid = (cfg.price_min + cfg.price_max) / 2;
+    double stddev = static_cast<double>(cfg.price_max - cfg.price_min) / 6.0;
+    std::normal_distribution<double> price_dist(
+        static_cast<double>(mid), stddev
+    );
+    std::uniform_int_distribution<orderbook::Quantity> qty_dist(1, cfg.max_quantity);
+    std::uniform_int_distribution<int> side_dist(0, 1);
+    std::uniform_real_distribution<double> cancel_dist(0.0, 1.0);
+
+    std::vector<BenchOp> ops;
+    ops.reserve(cfg.num_orders);
+
+    orderbook::OrderId next_id = 1;
+    std::vector<orderbook::OrderId> active_ids;
+    active_ids.reserve(cfg.num_orders);
+
+    for (std::size_t i = 0; i < cfg.num_orders; ++i) {
+        bool do_cancel = !active_ids.empty() && cancel_dist(rng) < cfg.cancel_ratio;
+
+        if (do_cancel) {
+            std::uniform_int_distribution<std::size_t> idx_dist(
+                0, active_ids.size() - 1
+            );
+            std::size_t idx = idx_dist(rng);
+            orderbook::OrderId cancel_id = active_ids[idx];
+            active_ids[idx] = active_ids.back();
+            active_ids.pop_back();
+
+            BenchOp op{};
+            op.action = Action::Cancel;
+            op.order.id = cancel_id;
+            ops.push_back(op);
+        } else {
+            BenchOp op{};
+            op.action = Action::Add;
+            op.order.id = next_id++;
+
+            // Clamp to price range.
+            auto raw_price = static_cast<orderbook::Price>(price_dist(rng));
+            op.order.price = std::clamp(raw_price, cfg.price_min, cfg.price_max);
+
+            op.order.quantity = qty_dist(rng);
+            op.order.side = side_dist(rng) == 0
+                ? orderbook::Side::Buy
+                : orderbook::Side::Sell;
+            op.order.type = orderbook::OrderType::Limit;
+            op.order.timestamp = static_cast<orderbook::Timestamp>(i);
+            ops.push_back(op);
+
+            active_ids.push_back(op.order.id);
+        }
+    }
+
+    return ops;
+}
+
+/// Generates add-only workload (no cancels). Useful for measuring
+/// pure add+match throughput without cancel noise.
+inline std::vector<BenchOp> generate_add_only(const GeneratorConfig& cfg) {
+    GeneratorConfig no_cancel = cfg;
+    no_cancel.cancel_ratio = 0.0;
+    return generate_uniform(no_cancel);
+}
+
+} // namespace bench

--- a/benchmarks/results/baseline.md
+++ b/benchmarks/results/baseline.md
@@ -1,0 +1,85 @@
+# Benchmark Results — Phase 3 Baseline
+
+> These are the initial baseline numbers before any optimization work (Phase 4).
+> Every future optimization PR will include updated numbers against this baseline.
+>
+> **To reproduce:** Build in Release mode and run the benchmark binary.
+> Results will vary by hardware — what matters is relative improvement.
+
+## How to Run
+
+```bash
+# Build with optimizations
+cmake -B build -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-O3 -march=native" \
+    -DBUILD_BENCHMARKS=ON
+cmake --build build
+
+# Run the benchmark suite
+./build/benchmarks/orderbook_bench
+
+# Or use the helper script
+./tools/run_benchmarks.sh
+```
+
+## Results
+
+> Run these benchmarks on YOUR machine and replace the table below with your
+> actual numbers. The numbers below are from a containerized environment and
+> won't reflect your hardware's true performance.
+
+| Benchmark | Throughput | p50 | p99 | p99.9 |
+|-----------|-----------|-----|-----|-------|
+| *(Run benchmarks and paste your results here)* | | | | |
+
+## Scenarios Explained
+
+### OrderBook add+cancel (uniform)
+Raw `OrderBook::add_order()` + `OrderBook::cancel_order()` throughput without
+the matching engine. Measures the cost of the core data structures in isolation:
+`std::map` lookup for price levels, intrusive list insert/remove, and
+`unordered_map` index updates.
+
+### MatchingEngine submit+cancel (uniform)
+Full matching engine path: orders are submitted, potentially matched against the
+opposite side, and cancelled. Prices are uniformly distributed across a 200-tick
+range, so some orders will cross and generate trades.
+
+### MatchingEngine submit+cancel (clustered)
+Same as above but with a normal distribution around the mid-price. This is more
+realistic — in real markets, most order flow clusters near the current price.
+Expect better cache behavior (fewer unique price levels accessed).
+
+### MatchingEngine add-only (no cancels)
+Pure order insertion throughput with no cancellations. The book grows continuously.
+This stresses the `std::map` insertion path and shows how performance degrades
+as the book gets deeper.
+
+### Bulk throughput (best of 3)
+Wall-clock measurement of total time to process 500K operations, reported as
+the best of 3 runs. This avoids per-operation timer overhead and gives the
+truest throughput number.
+
+## Methodology
+
+- **Operations per scenario:** 500,000 (configurable via command line argument)
+- **Warmup:** 10,000 operations before timing begins
+- **Timing:** `std::chrono::high_resolution_clock` with compiler fences to prevent reordering
+- **Optimizer prevention:** `do_not_optimize()` barriers prevent dead code elimination
+- **Reproducibility:** Fixed RNG seed (42) for all scenarios
+- **Build:** Release mode with `-O3 -march=native`
+- **Architecture:** Single-threaded (matches real exchange design)
+- **Order generation:** Pre-allocated before timing to exclude allocation cost
+
+## What to Look For in Phase 4
+
+The baseline numbers establish our starting point. Key areas to optimize:
+
+1. **`std::map` overhead** — O(log N) per price level lookup. An array-backed
+   structure could give O(1) for dense price ranges.
+2. **Allocation overhead** — `std::map` allocates tree nodes on the heap.
+   A pool allocator could eliminate this.
+3. **Cache misses** — Orders are scattered in memory. An arena allocator
+   with contiguous storage would improve locality.
+4. **`std::vector<Trade>` in MatchResult** — Allocates on every match.
+   A pre-allocated trade buffer would eliminate this hot-path allocation.

--- a/benchmarks/throughput_bench.cpp
+++ b/benchmarks/throughput_bench.cpp
@@ -1,9 +1,321 @@
 // benchmarks/throughput_bench.cpp
-// Benchmark suite — Phase 3 (planned).
+//
+// Benchmark suite for the order book and matching engine.
+//
+// Measures:
+//   1. OrderBook add/cancel throughput (no matching)
+//   2. MatchingEngine submit throughput (with matching)
+//   3. Per-operation latency with percentile breakdown
+//   4. Different workload profiles (uniform, clustered, add-only)
+//
+// Run with:
+//   cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON
+//   cmake --build build
+//   ./build/benchmarks/orderbook_bench
+//
+// IMPORTANT: Always benchmark in Release mode (-O2/-O3).
+// Debug mode includes assertions and sanitizer overhead.
+
+#include "orderbook/matching_engine.hpp"
+#include "bench_harness.hpp"
+#include "order_generator.hpp"
 
 #include <iostream>
+#include <memory>
+#include <vector>
+#include <cstring>
 
-int main() {
-    std::cout << "Benchmarks not yet implemented — see Phase 3 in docs/ROADMAP.md\n";
+using namespace orderbook;
+using namespace bench;
+
+// ══════════════════════════════════════════════════════════
+// Benchmark 1: Raw OrderBook add + cancel (no matching)
+// ══════════════════════════════════════════════════════════
+
+LatencyStats bench_orderbook_add_cancel(std::size_t num_ops) {
+    auto ops = generate_uniform(GeneratorConfig{
+        .num_orders = num_ops,
+        .cancel_ratio = 0.3,
+        .seed = 42
+    });
+
+    // Pre-allocate orders. The book holds raw pointers, so we need
+    // stable storage. Use a vector of Order indexed by ID.
+    std::vector<Order> order_storage(num_ops + 1);
+
+    OrderBook book;
+    std::vector<Duration> latencies;
+    latencies.reserve(num_ops);
+
+    for (auto& op : ops) {
+        if (op.action == Action::Add) {
+            // Copy into stable storage.
+            order_storage[op.order.id] = op.order;
+            Order* o = &order_storage[op.order.id];
+
+            fence();
+            auto start = Clock::now();
+            book.add_order(o);
+            auto end = Clock::now();
+            fence();
+
+            latencies.push_back(
+                std::chrono::duration_cast<Duration>(end - start)
+            );
+        } else {
+            fence();
+            auto start = Clock::now();
+            book.cancel_order(op.order.id);
+            auto end = Clock::now();
+            fence();
+
+            latencies.push_back(
+                std::chrono::duration_cast<Duration>(end - start)
+            );
+        }
+    }
+
+    do_not_optimize(book);
+    return compute_stats("OrderBook add+cancel (uniform)", latencies);
+}
+
+// ══════════════════════════════════════════════════════════
+// Benchmark 2: Matching engine throughput (with matching)
+// ══════════════════════════════════════════════════════════
+
+LatencyStats bench_matching_engine(std::size_t num_ops,
+                                   const std::string& profile) {
+    GeneratorConfig cfg{
+        .num_orders = num_ops,
+        .cancel_ratio = 0.3,
+        .seed = 42
+    };
+
+    auto ops = (profile == "clustered")
+        ? generate_clustered(cfg)
+        : generate_uniform(cfg);
+
+    // Storage for orders.
+    std::vector<Order> order_storage(num_ops + 1);
+
+    MatchingEngine engine;
+    std::vector<Duration> latencies;
+    latencies.reserve(num_ops);
+
+    for (auto& op : ops) {
+        if (op.action == Action::Add) {
+            order_storage[op.order.id] = op.order;
+            Order* o = &order_storage[op.order.id];
+
+            fence();
+            auto start = Clock::now();
+            auto result = engine.submit_order(o);
+            auto end = Clock::now();
+            fence();
+
+            do_not_optimize(result);
+            latencies.push_back(
+                std::chrono::duration_cast<Duration>(end - start)
+            );
+        } else {
+            fence();
+            auto start = Clock::now();
+            engine.cancel_order(op.order.id);
+            auto end = Clock::now();
+            fence();
+
+            latencies.push_back(
+                std::chrono::duration_cast<Duration>(end - start)
+            );
+        }
+    }
+
+    do_not_optimize(engine);
+    std::string name = "MatchingEngine submit+cancel (" + profile + ")";
+    return compute_stats(name, latencies);
+}
+
+// ══════════════════════════════════════════════════════════
+// Benchmark 3: Add-only throughput (pure insertion, no matching)
+// ══════════════════════════════════════════════════════════
+
+LatencyStats bench_add_only(std::size_t num_ops) {
+    GeneratorConfig cfg{
+        .num_orders = num_ops,
+        .cancel_ratio = 0.0,
+        .seed = 42
+    };
+    auto ops = generate_uniform(cfg);
+
+    std::vector<Order> order_storage(num_ops + 1);
+    MatchingEngine engine;
+    std::vector<Duration> latencies;
+    latencies.reserve(num_ops);
+
+    for (auto& op : ops) {
+        order_storage[op.order.id] = op.order;
+        Order* o = &order_storage[op.order.id];
+
+        fence();
+        auto start = Clock::now();
+        auto result = engine.submit_order(o);
+        auto end = Clock::now();
+        fence();
+
+        do_not_optimize(result);
+        latencies.push_back(
+            std::chrono::duration_cast<Duration>(end - start)
+        );
+    }
+
+    do_not_optimize(engine);
+    return compute_stats("MatchingEngine add-only (no cancels)", latencies);
+}
+
+// ══════════════════════════════════════════════════════════
+// Benchmark 4: Bulk throughput measurement (wall-clock)
+//
+// Instead of timing each operation individually (which adds
+// timer overhead), this measures total wall-clock time for
+// processing a batch. Gives a truer throughput number.
+// ══════════════════════════════════════════════════════════
+
+void bench_bulk_throughput(std::size_t num_ops) {
+    GeneratorConfig cfg{
+        .num_orders = num_ops,
+        .cancel_ratio = 0.3,
+        .seed = 42
+    };
+    auto ops = generate_uniform(cfg);
+    std::vector<Order> order_storage(num_ops + 1);
+
+    // Prepare orders in storage first.
+    for (auto& op : ops) {
+        if (op.action == Action::Add) {
+            order_storage[op.order.id] = op.order;
+        }
+    }
+
+    // Run 3 iterations, report best.
+    double best_throughput = 0.0;
+
+    for (int run = 0; run < 3; ++run) {
+        // Reset: create fresh engine, reset order states.
+        MatchingEngine engine;
+        for (auto& op : ops) {
+            if (op.action == Action::Add) {
+                Order& o = order_storage[op.order.id];
+                o.filled_quantity = 0;
+                o.status = OrderStatus::New;
+                o.prev = nullptr;
+                o.next = nullptr;
+            }
+        }
+
+        fence();
+        auto start = Clock::now();
+
+        for (auto& op : ops) {
+            if (op.action == Action::Add) {
+                engine.submit_order(&order_storage[op.order.id]);
+            } else {
+                engine.cancel_order(op.order.id);
+            }
+        }
+
+        auto end = Clock::now();
+        fence();
+        do_not_optimize(engine);
+
+        double elapsed_sec = std::chrono::duration<double>(end - start).count();
+        double throughput = static_cast<double>(num_ops) / elapsed_sec;
+        best_throughput = std::max(best_throughput, throughput);
+    }
+
+    std::cout << "\n┌─────────────────────────────────────────────┐\n";
+    std::cout << "│ Bulk throughput (best of 3 runs)             │\n";
+    std::cout << "├─────────────────────────────────────────────┤\n";
+    std::cout << "│ Operations:    " << std::setw(28) << num_ops << " │\n";
+    std::cout << "│ Throughput:    " << std::setw(28)
+              << format_throughput(best_throughput) << " │\n";
+    std::cout << "└─────────────────────────────────────────────┘\n";
+}
+
+// ══════════════════════════════════════════════════════════
+// Main
+// ══════════════════════════════════════════════════════════
+
+int main(int argc, char* argv[]) {
+    std::size_t num_ops = 500'000; // Default
+
+    // Allow overriding from command line.
+    if (argc > 1) {
+        num_ops = static_cast<std::size_t>(std::atol(argv[1]));
+    }
+
+    std::cout << "═══════════════════════════════════════════════\n";
+    std::cout << " Order Book Engine — Benchmark Suite\n";
+    std::cout << " Operations per test: " << num_ops << "\n";
+    std::cout << "═══════════════════════════════════════════════\n";
+
+    // Warmup run — primes caches, triggers JIT-like effects.
+    {
+        std::cout << "\n[Warmup...]\n";
+        auto warmup_ops = generate_uniform(GeneratorConfig{
+            .num_orders = 10'000,
+            .seed = 99
+        });
+        std::vector<Order> warmup_storage(10'001);
+        MatchingEngine warmup_engine;
+        for (auto& op : warmup_ops) {
+            if (op.action == Action::Add) {
+                warmup_storage[op.order.id] = op.order;
+                warmup_engine.submit_order(&warmup_storage[op.order.id]);
+            } else {
+                warmup_engine.cancel_order(op.order.id);
+            }
+        }
+        do_not_optimize(warmup_engine);
+    }
+
+    // Run benchmarks.
+    std::cout << "\n── Per-operation latency benchmarks ──\n";
+
+    auto stats1 = bench_orderbook_add_cancel(num_ops);
+    print_stats(stats1);
+
+    auto stats2 = bench_matching_engine(num_ops, "uniform");
+    print_stats(stats2);
+
+    auto stats3 = bench_matching_engine(num_ops, "clustered");
+    print_stats(stats3);
+
+    auto stats4 = bench_add_only(num_ops);
+    print_stats(stats4);
+
+    std::cout << "\n── Bulk throughput benchmark ──\n";
+    bench_bulk_throughput(num_ops);
+
+    // Summary table for easy copy-paste into docs.
+    std::cout << "\n\n── Summary ──\n\n";
+    std::cout << "| Benchmark | Throughput | p50 | p99 | p99.9 |\n";
+    std::cout << "|-----------|-----------|-----|-----|-------|\n";
+
+    auto print_row = [](const LatencyStats& s) {
+        std::cout << "| " << std::left << std::setw(40) << s.name
+                  << " | " << std::setw(18)
+                  << format_throughput(s.throughput_ops_per_sec)
+                  << " | " << std::setw(12) << format_duration(s.p50)
+                  << " | " << std::setw(12) << format_duration(s.p99)
+                  << " | " << std::setw(12) << format_duration(s.p999)
+                  << " |\n";
+    };
+
+    print_row(stats1);
+    print_row(stats2);
+    print_row(stats3);
+    print_row(stats4);
+
+    std::cout << "\n";
     return 0;
 }

--- a/src/matching/matching_engine.cpp
+++ b/src/matching/matching_engine.cpp
@@ -94,6 +94,9 @@ void MatchingEngine::match_buy(Order* incoming, MatchResult& result) {
             if (resting->is_filled()) {
                 resting->status = OrderStatus::Filled;
                 book_.remove_filled_order(resting);
+                // Level may have been erased from the map (freed).
+                // Break to the outer loop which re-fetches a fresh pointer.
+                break;
             } else {
                 resting->status = OrderStatus::PartiallyFilled;
                 level->reduce_total_quantity(fill_qty);
@@ -142,6 +145,7 @@ void MatchingEngine::match_sell(Order* incoming, MatchResult& result) {
             if (resting->is_filled()) {
                 resting->status = OrderStatus::Filled;
                 book_.remove_filled_order(resting);
+                break;
             } else {
                 resting->status = OrderStatus::PartiallyFilled;
                 level->reduce_total_quantity(fill_qty);

--- a/tools/run_benchmarks.sh
+++ b/tools/run_benchmarks.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# tools/run_benchmarks.sh
+#
+# Builds and runs the benchmark suite.
+#
+# Usage:
+#   ./tools/run_benchmarks.sh                # Default: 500K ops
+#   ./tools/run_benchmarks.sh 1000000        # Custom op count
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BUILD_DIR="$PROJECT_DIR/build-bench"
+
+NUM_OPS="${1:-500000}"
+
+echo "=== Order Book Engine — Benchmark Runner ==="
+echo ""
+
+# Build in Release mode with benchmarks enabled
+echo "Building in Release mode..."
+cmake -B "$BUILD_DIR" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_BENCHMARKS=ON \
+    -S "$PROJECT_DIR" \
+    > /dev/null 2>&1
+
+cmake --build "$BUILD_DIR" --parallel "$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)" \
+    > /dev/null 2>&1
+
+echo "Build complete."
+echo ""
+
+BENCH_BIN="$BUILD_DIR/benchmarks/orderbook_bench"
+
+if [ ! -f "$BENCH_BIN" ]; then
+    echo "ERROR: Benchmark binary not found at $BENCH_BIN"
+    exit 1
+fi
+
+# System info
+echo "System info:"
+echo "  OS:       $(uname -s) ($(uname -m))"
+echo "  Compiler: $(c++ --version 2>/dev/null | head -1 || echo 'unknown')"
+echo "  Date:     $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+echo ""
+
+# Run
+echo "Running benchmarks ($NUM_OPS operations per test)..."
+echo ""
+"$BENCH_BIN" "$NUM_OPS"
+
+echo ""
+echo "Done. Copy the summary table above into benchmarks/results/baseline.md"


### PR DESCRIPTION
- Custom bench harness with nanosecond timing, percentile stats, compiler fences, and optimizer barriers
- Synthetic order generator: uniform and clustered price distributions with configurable cancel ratio and fixed seed for reproducibility
- Four benchmark scenarios: raw book ops, matching (uniform/clustered), add-only, and bulk wall-clock throughput (best of 3)
- Baseline results template in benchmarks/results/baseline.md
- Helper script: tools/run_benchmarks.sh